### PR TITLE
Update Jedi to 0.10.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  fn: jedu-v{{ version }}.tar.gz
+  fn: jedi-v{{ version }}.tar.gz
   url: https://github.com/davidhalter/jedi/archive/v{{ version }}.tar.gz
   sha256: d6a7344df9c80562c3f62199278004ccc7c5889be9f1a6aa5abde117ec085123
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,8 +6,9 @@ package:
   version: {{ version }}
 
 source:
-  git_url: https://github.com/davidhalter/jedi.git
-  git_tag: v{{ version }}
+  fn: jedu-v{{ version }}.tar.gz
+  url: https://github.com/davidhalter/jedi/archive/v{{ version }}.tar.gz
+  sha256: d6a7344df9c80562c3f62199278004ccc7c5889be9f1a6aa5abde117ec085123
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,3 +42,4 @@ about:
 extra:
   recipe-maintainers:
     - goanpeca
+    - asmeurer

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,16 +1,13 @@
 {% set name = "jedi" %}
-{% set version = "0.9.0" %}
-{% set hash_type = "sha256" %}
-{% set hash = "3b4c19fba31bdead9ab7350fb9fa7c914c59b0a807dcdd5c00a05feb85491d31" %}
+{% set version = "0.10.0" %}
 
 package:
   name: {{ name }}
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  {{ hash_type }}: {{ hash }}
+  git_url: https://github.com/davidhalter/jedi.git
+  git_tag: v{{ version }}
 
 build:
   number: 0


### PR DESCRIPTION
The download url had to be changed to git since there is no sdist uploaded for
0.10.0.